### PR TITLE
Hotfix 1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 1.5.5 - 2023-05-17
+
+### FIXES
+- fix: remove PriceFieldName attribute from search handler
+  There is no need to send PriceFieldName attribute ("I" parameter in the
+  request) in the API request.  The parameter "I" can be empty.
+  It is enough to have the profile name configured in Celebros
+  and it will defined the correct price field.
+  
+  Refs #SSUITE-893
+
 ## 1.5.4
 
 ### FIXES

--- a/Model/Search.php
+++ b/Model/Search.php
@@ -225,7 +225,6 @@ class Search
         }
 
         // some mandatory arguments
-        $searchInfoXml->setAttribute('PriceFieldName', 'Price');
         $searchInfoXml->setAttribute('NumberOfPages', 9999999);
 
         return $searchInfoXml;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "celebros/module-conversionpro-embedded",
     "description": "Celebros ConversionPro Embedded",
     "type": "magento2-module",
-    "version": "1.5.4",
+    "version": "1.5.5",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
    */
   -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Celebros_ConversionPro" setup_version="1.5.4">
+    <module name="Celebros_ConversionPro" setup_version="1.5.5">
         <sequence>
             <module name="Magento_LayeredNavigation"/>
             <module name="Celebros_Main"/>


### PR DESCRIPTION
[fix: remove PriceFieldName attribute from search handler](https://github.com/CelebrosLtd/M2_ConversionPro_Embedded/commit/edb911d40a121ac029cadae0c49ee80e1cae4cca) 

There is no need to send PriceFieldName attribute ("I" parameter in the
request) in the API request.  The parameter "I" can be empty.
It is enough to have the profile name configured in Celebros
and it will defined the correct price field.

Refs #SSUITE-893